### PR TITLE
Update 2b_ManagementInfraPS.md

### DIFF
--- a/nested/steps/2b_ManagementInfraPS.md
+++ b/nested/steps/2b_ManagementInfraPS.md
@@ -384,7 +384,7 @@ $domainAdmin = "$domainName\labadmin"
 $domainCreds = Get-Credential -UserName "$domainAdmin" -Message "Enter the password for the LabAdmin account"
 Invoke-Command -VMName "MGMT01" -Credential $w10Creds -ScriptBlock {
     # Rename and join domain
-    Add-Computer –DomainName azshci.local -NewName "MGMT01" –Credential $using:domainCreds -Force
+    Add-Computer -DomainName azshci.local -NewName "MGMT01" -Credential $using:domainCreds -Force
 }
 
 Write-Verbose "Rebooting MGMT01 for hostname change to take effect" -Verbose


### PR DESCRIPTION
FIX: Replace wrong with correct dash (- instead of –) at the domain join step of the Windows 10 VM.