### PR TITLE
Update 3b_AzSHCINodesPS.md

### DIFF
--- a/nested/steps/3b_AzSHCINodesPS.md
+++ b/nested/steps/3b_AzSHCINodesPS.md
@@ -143,7 +143,7 @@ $domainCreds = Get-Credential -UserName "$domainAdmin" -Message "Enter the passw
 $nodeName = "AZSHCINODE01"
 Invoke-Command -VMName "$nodeName" -Credential $azsHCILocalCreds -ScriptBlock {
     # Join the domain and change the name at the same time
-    Add-Computer –DomainName azshci.local -NewName $Using:nodeName –Credential $Using:domainCreds -Force
+    Add-Computer -DomainName azshci.local -NewName $Using:nodeName -Credential $Using:domainCreds -Force
 }
 
 Write-Verbose "Rebooting node for changes to take effect" -Verbose


### PR DESCRIPTION
FIX: Replace wrong with correct dash (- instead of –) at the domain join step of the Azure Stack HCI node.